### PR TITLE
Allow the caller to specify any ruby-snmp type.

### DIFF
--- a/lib/snmp4em/requests/snmp_set_request.rb
+++ b/lib/snmp4em/requests/snmp_set_request.rb
@@ -29,6 +29,8 @@ module SNMP4EM
           snmp_value = SNMP::Integer.new(value)
         elsif value.is_a? String
           snmp_value = SNMP::OctetString.new(value)
+        else
+          snmp_value = value
         end
         
         @pending_varbinds << SNMP::VarBind.new(oid,snmp_value)


### PR DESCRIPTION
I ran into a problem when dealing with other types.
