### PR TITLE
Replace <=> comparison with is_a? for SNMP::EndOfMibView check

### DIFF
--- a/lib/snmp4em/requests/snmp_bulkwalk_request.rb
+++ b/lib/snmp4em/requests/snmp_bulkwalk_request.rb
@@ -33,7 +33,7 @@ module SNMP4EM
 
           next unless oid[:state] == :pending
 
-          if response_vb.value == SNMP::EndOfMibView
+          if response_vb.value.is_a? SNMP::EndOfMibView
             oid[:state] = :complete
 
           elsif ! response_oid.subtree_of?(oid[:requested_oid])
@@ -68,13 +68,13 @@ module SNMP4EM
     end
 
     private
-    
+
     def send_msg
       Manager.track_request(self)
 
       vb_list = SNMP::VarBindList.new(pending_oids.collect{|oid| oid[:next_oid]})
       request = SNMP::GetBulkRequest.new(@snmp_id, vb_list)
-      
+
       request.max_repetitions = 10
       request.non_repeaters = 0
 
@@ -82,5 +82,5 @@ module SNMP4EM
 
       super(message)
     end
-  end  
+  end
 end

--- a/lib/snmp4em/requests/snmp_walk_request.rb
+++ b/lib/snmp4em/requests/snmp_walk_request.rb
@@ -26,7 +26,7 @@ module SNMP4EM
         pending_oids.zip(response.varbind_list).each do |oid, response_vb|
           response_oid = response_vb.name
 
-          if response_vb.value == SNMP::EndOfMibView
+          if response_vb.value.is_a? SNMP::EndOfMibView
             # For SNMPv2, this indicates we've reached the end of the MIB
             oid[:state] = :complete
           elsif ! response_oid.subtree_of?(oid[:requested_oid])
@@ -64,7 +64,7 @@ module SNMP4EM
     end
 
     private
-    
+
     def send_msg
       Manager.track_request(self)
 
@@ -74,5 +74,5 @@ module SNMP4EM
 
       super(message)
     end
-  end  
+  end
 end


### PR DESCRIPTION
Within the <=> comparable method of the SNMP::Integer class, the
‘other’ side of the comparison is hit with to_i.  In these three cases
when checking to see if `value == SNMP::EndOfMibView`,
`EndOfMibView.to_i` is called and raises an error which is no longer
handled with Ruby 2.3.

I have simply changed the three instances of `value ==
SNMP::EndOfMibView` to use `value.is_a? SNMP::EndOfMibView` instead,
which is a valid comparison regardless of the returned object.

I don’t know the underlying reason for checking for this class to begin
with, so this may not be the appropriate solution.