### PR TITLE
Remove global state on SNMP4EM::Manager

### DIFF
--- a/lib/snmp4em/handler.rb
+++ b/lib/snmp4em/handler.rb
@@ -1,5 +1,11 @@
 module SNMP4EM
   class Handler < EventMachine::Connection  # @private
+    def initialize(manager)
+      super
+
+      @manager = manager
+    end
+
     def receive_data(data)
       begin
         message = SNMP::Message.decode(data)
@@ -17,7 +23,7 @@ module SNMP4EM
       # request, ignore it.
       #
 
-      if request = Manager.pending_requests[response.request_id]
+      if request = @manager.pending_requests[response.request_id]
         request.handle_response(response)
       end
     end

--- a/lib/snmp4em/manager.rb
+++ b/lib/snmp4em/manager.rb
@@ -67,14 +67,10 @@ module SNMP4EM
         request.snmp_id = @next_index
       end while @pending_requests[request.snmp_id]
 
-      warn "TRACK: #{request.snmp_id}"
-      warn "Number of pending requests: #{@pending_requests.size}"
-
       @pending_requests[request.snmp_id] = request
     end
 
     def untrack_request(snmp_id)
-      warn "UNTRACK#{snmp_id}"
       @pending_requests.delete(snmp_id)
     end
     

--- a/lib/snmp4em/manager.rb
+++ b/lib/snmp4em/manager.rb
@@ -13,41 +13,9 @@ module SNMP4EM
     #
     # @pending_requests maps a request's id to its SnmpRequest
     #
-    @pending_requests = {}
-    @socket = nil
     
-    class << self
-      attr_reader :pending_requests
-      attr_reader :socket
-      
-      # Initializes the outgoing socket. Checks to see if it's in an error state, and if so closes and reopens the socket
-      def init_socket
-        if !@socket.nil? && @socket.error?
-          @socket.close_connection
-          @socket = nil
-        end
-
-        @next_index ||= rand(MAX_INDEX)
-        @socket ||= EM::open_datagram_socket("0.0.0.0", 0, Handler)
-      end
-
-      # Assigns an SNMP ID to an outgoing request so that it can be matched with its incoming response
-      def track_request(request)
-        untrack_request(request.snmp_id)
-
-        begin
-          @next_index = (@next_index + 1) % MAX_INDEX
-          request.snmp_id = @next_index
-        end while @pending_requests[request.snmp_id]
-
-        @pending_requests[request.snmp_id] = request
-      end
-
-      def untrack_request(snmp_id)
-        @pending_requests.delete(snmp_id)
-      end
-    end
-    
+    attr_reader :pending_requests
+    attr_reader :socket
     attr_reader :host, :port, :timeout, :retries, :version, :community_ro, :community_rw
     
     # Creates a new object to communicate with SNMP agents. Optionally pass in the following parameters:
@@ -72,14 +40,48 @@ module SNMP4EM
 
       @community_ro = args[:community_ro] || args[:community] || "public"
       @community_rw = args[:community_rw] || args[:community] || "public"
+
+      @pending_requests = {}
+      @socket = nil
       
-      self.class.init_socket
+      init_socket
+    end
+    
+    # Initializes the outgoing socket. Checks to see if it's in an error state, and if so closes and reopens the socket
+    def init_socket
+      if !@socket.nil? && @socket.error?
+        @socket.close_connection
+        @socket = nil
+      end
+
+      @next_index ||= rand(MAX_INDEX)
+      @socket ||= EM::open_datagram_socket("0.0.0.0", 0, Handler, self)
+    end
+
+    # Assigns an SNMP ID to an outgoing request so that it can be matched with its incoming response
+    def track_request(request)
+      untrack_request(request.snmp_id)
+
+      begin
+        @next_index = (@next_index + 1) % MAX_INDEX
+        request.snmp_id = @next_index
+      end while @pending_requests[request.snmp_id]
+
+      warn "TRACK: #{request.snmp_id}"
+      warn "Number of pending requests: #{@pending_requests.size}"
+
+      @pending_requests[request.snmp_id] = request
+    end
+
+    def untrack_request(snmp_id)
+      warn "UNTRACK#{snmp_id}"
+      @pending_requests.delete(snmp_id)
     end
     
     def send_msg(message) # @private
-      self.class.socket.send_datagram message.encode, @host, @port
+      socket.send_datagram message.encode, @host, @port
     rescue EventMachine::ConnectionError
-      self.class.untrack_request message.pdu.request_id
+      untrack_request message.pdu.request_id
       raise
     end
 

--- a/lib/snmp4em/requests/snmp_bulkwalk_request.rb
+++ b/lib/snmp4em/requests/snmp_bulkwalk_request.rb
@@ -69,8 +69,8 @@ module SNMP4EM
 
     private
     
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       vb_list = SNMP::VarBindList.new(pending_oids.collect{|oid| oid[:next_oid]})
 
@@ -86,7 +86,7 @@ module SNMP4EM
 
       message = SNMP::Message.new(@sender.version, @sender.community_ro, request)
 
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/requests/snmp_get_request.rb
+++ b/lib/snmp4em/requests/snmp_get_request.rb
@@ -42,13 +42,13 @@ module SNMP4EM
         return
       end
     
-      send_msg
+      send_self
     end
 
     private
 
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       query_oids = @oids.select{|oid| oid[:state] == :pending}.collect{|oid| oid[:requested_oid]}
 
@@ -56,7 +56,7 @@ module SNMP4EM
       request = SNMP::GetRequest.new(@snmp_id, vb_list)
       message = SNMP::Message.new(@sender.version, @sender.community_ro, request)
 
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/requests/snmp_getbulk_request.rb
+++ b/lib/snmp4em/requests/snmp_getbulk_request.rb
@@ -67,13 +67,13 @@ module SNMP4EM
         return
       end
 
-      send_msg
+      send_self
     end
 
     private
 
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       vb_list = SNMP::VarBindList.new(pending_oids.collect{|oid| oid[:requested_oid]})
 
@@ -92,7 +92,7 @@ module SNMP4EM
 
       message = SNMP::Message.new(@sender.version, @sender.community_ro, request)
 
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/requests/snmp_getnext_request.rb
+++ b/lib/snmp4em/requests/snmp_getnext_request.rb
@@ -49,13 +49,13 @@ module SNMP4EM
         return
       end
     
-      send_msg
+      send_self
     end
 
     private
     
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       query_oids = @oids.select{|oid| oid[:state] == :pending}.collect{|oid| oid[:requested_oid]}
 
@@ -63,7 +63,7 @@ module SNMP4EM
       request = SNMP::GetNextRequest.new(@snmp_id, vb_list)
       message = SNMP::Message.new(@sender.version, @sender.community_ro, request)
       
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/requests/snmp_set_request.rb
+++ b/lib/snmp4em/requests/snmp_set_request.rb
@@ -47,13 +47,13 @@ module SNMP4EM
         return
       end
     
-      send_msg
+      send_self
     end
 
     private
     
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       pending_varbinds = pending_oids.collect{|oid| SNMP::VarBind.new(oid[:requested_oid], oid[:value])}
 
@@ -61,7 +61,7 @@ module SNMP4EM
       request = SNMP::SetRequest.new(@snmp_id, vb_list)
       message = SNMP::Message.new(@sender.version, @sender.community_rw, request)
       
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/requests/snmp_walk_request.rb
+++ b/lib/snmp4em/requests/snmp_walk_request.rb
@@ -60,19 +60,19 @@ module SNMP4EM
         return
       end
 
-      send_msg
+      send_self
     end
 
     private
     
-    def send_msg
-      Manager.track_request(self)
+    def send_self
+      @sender.track_request(self)
 
       vb_list = SNMP::VarBindList.new(pending_oids.collect{|oid| oid[:next_oid]})
       request = SNMP::GetNextRequest.new(@snmp_id, vb_list)
       message = SNMP::Message.new(@sender.version, @sender.community_ro, request)
 
-      super(message)
+      send_msg(message)
     end
   end  
 end

--- a/lib/snmp4em/snmp_request.rb
+++ b/lib/snmp4em/snmp_request.rb
@@ -52,12 +52,12 @@ module SNMP4EM
     
     def init_callbacks  # @private
       self.callback do
-        Manager.pending_requests.delete(@snmp_id)
+        Manager.untrack_request(@snmp_id)
       end
       
       self.errback do
         @timeout_timer.cancel
-        Manager.pending_requests.delete(@snmp_id)
+        Manager.untrack_request(@snmp_id)
       end
     end
 

--- a/lib/snmp4em/snmp_request.rb
+++ b/lib/snmp4em/snmp_request.rb
@@ -23,7 +23,7 @@ module SNMP4EM
       
       init_callbacks
       on_init(args) if respond_to?(:on_init)
-      send_msg
+      send_self
     end
 
     def pending_oids  # @private
@@ -52,12 +52,12 @@ module SNMP4EM
     
     def init_callbacks  # @private
       self.callback do
-        Manager.untrack_request(@snmp_id)
+        @sender.untrack_request(@snmp_id)
       end
       
       self.errback do
         @timeout_timer.cancel
-        Manager.untrack_request(@snmp_id)
+        @sender.untrack_request(@snmp_id)
       end
     end
 
@@ -72,7 +72,7 @@ module SNMP4EM
         if @timeouts.empty?
           fail "exhausted all timeout retries"
         else
-          send_msg
+          send_self
         end
       end
     end


### PR DESCRIPTION
This removes the global state on `SNMP4EM::Manager`, namely `.socket` and `.pending_requests`. The `Manager` object is passed to the `Handler` at creation, and the `.init_socket`, `.track_request`, and `.untrack_request` methods are turned into instance methods.

It also refactors the quirky implementations around `SNMP4EM::SnmpRequest#send_msg(msg)` (technically public API) and `#send_msg()` (takes no argument, private API) on all its subclasses. The private variant of the method without an argument is renamed to `#send_self`.